### PR TITLE
bugfix/accurics_remediation_4594374993838921 - Auto Generated Pull Request From Accurics

### DIFF
--- a/s3_bucket.tf
+++ b/s3_bucket.tf
@@ -1,0 +1,11 @@
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tenable_cs_demo_s3_bucketSseConfig" {
+  bucket = aws_s3_bucket.tenable_cs_demo_s3_bucket.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = "<master_kms_key_id>"
+    }
+  }
+}


### PR DESCRIPTION
Server-side encryption protects data at rest. Amazon S3 encrypts each object with a unique key. As an additional safeguard, it encrypts the key itself with a key that it rotates regularly. Amazon S3 server-side encryption uses one of the strongest block ciphers available to encrypt your data using AWS KMS Customer managed key.
 In Terraform - 
 Add the 'server_side_encryption_configuration' block to ensure server side encryption is enabled. Ensure 'see_algorithm' is set to 'aws:kms' and add a 'kms_master_key_id'.